### PR TITLE
Fixed RSS validation issues.

### DIFF
--- a/_harp/feeds/rss.xml.ejs
+++ b/_harp/feeds/rss.xml.ejs
@@ -16,22 +16,22 @@
 	<atom:link href="http://toolsday.io/feeds/rss.xml" rel="self" type="application/rss+xml" />
 	<link>http://toolsday.io</link>
 	<description>Toolsday is a 20-minute podcast about the latest in tech tools, tips, and tricks on Tuesdays at 2! (Our alliteration game is so strong). The podast is brought to you by Chris Dhanaraj and Una Kravets, and recorded live on IBM radio. After the show, we collect resources and post our episodes here.</description>
-	<lastBuildDate><%= Date() %></lastBuildDate>
+	<lastBuildDate><%= new Date().toUTCString() %></lastBuildDate>
 	<language>en-US</language>
 	<sy:updatePeriod>hourly</sy:updatePeriod>
 	<sy:updateFrequency>1</sy:updateFrequency>
 	<generator>http://harpjs.com</generator>
 	<copyright>Copyright © Una Kravets and Chris Dhanaraj 2015</copyright>
-	<managingEditor>una.kravets@gmail.com</managingEditor>
-	<webMaster>una.kravets@gmail.com</webMaster>
+	<managingEditor>una.kravets@gmail.com (Una Kravets)</managingEditor>
+	<webMaster>una.kravets@gmail.com (Una Kravets)</webMaster>
 	<category>Web, Development</category>
 	<ttl>1440</ttl>
 	<image>
 		<url>http://toolsday.io/img/logo-1400-1400.png</url>
 		<title>Toolsday</title>
 		<link>http://toolsday.io</link>
-		<width>1400</width>
-		<height>1400</height>
+		<width>144</width>
+		<height>400</height>
 	</image>
 	<itunes:subtitle>Hosted by Una Kravets and Chris Dhanaraj</itunes:subtitle>
 	<itunes:summary>20 minutes of tech tool talk on Tuesdays at 2.</itunes:summary>
@@ -54,7 +54,7 @@
 	<item>
 		<title><%= public.episodes._data[slug].title %></title>
 		<link>http://toolsday.io/episodes/<%= slug %>.html</link>
-		<pubDate><%= new Date(public.episodes._data[slug].date).toString() %></pubDate>
+		<pubDate><%= new Date(public.episodes._data[slug].date).toUTCString() %></pubDate>
 		<guid isPermaLink="true">http://toolsday.io/episodes/<%= slug %>.html</guid>
 		<description><![CDATA[<%= public.episodes._data[slug].description %>]]></description>
 		<itunes:summary><%= public.episodes._data[slug].description %></itunes:summary>


### PR DESCRIPTION
Hi there, I could replicate some issues with RSS validation, specifically two:

  - Dates should be in RFC-822, and that's achieved with .toUTCString(). .toString() generates dates in a different format.

```
> new Date().toString()
'Mon Nov 30 2015 20:10:27 GMT-0300 (CLT)'
> new Date().toUTCString()
'Mon, 30 Nov 2015 23:10:32 GMT'
```

  - Images shouldn't be larger than 144x400 in normal RSS (iTunes uses a different, namespaced format). I changed the width and height, but my skills are inexistent to create an image.

  - E-mail addresses must have a name enclosed between parentheses. Added it for the tag `<managingEditor>`

None of these seems to be the root cause of the issues with iTunes and Overcast.fm reported earlier; I couldn't replicate the issue, it successfully updated new episodes with many (32!!!) RSS readers on iOS, Android, Linux and Windows.